### PR TITLE
[fix] アーカイブ時にstring_idとstring_typeが欠落する不具合を修正

### DIFF
--- a/src/update.py
+++ b/src/update.py
@@ -184,8 +184,10 @@ def main():
         # 削除された項目のデータを取得してアーカイブ用に加工
         deleted_items = []
         for key in deleted_keys:
-            # 行データを取得
-            row_data = old_translate_sheet_df_keyed.loc[key].tolist()
+            # 行データを取得 (text_body以降)
+            row_values = old_translate_sheet_df_keyed.loc[key].tolist()
+            # key (string_id, string_type) をリストに変換して結合
+            row_data = list(key) + row_values
             # アーカイブ日時を追加
             row_data.append(current_datetime)
             deleted_items.append(row_data)


### PR DESCRIPTION
## 概要

`update.py` を実行した際に、ゲームから削除されたテキスト情報を記録する `archive` シートで、`string_id` と `string_type` の値が欠落する不具合を修正しました。

## 変更前の問題点

現状では、`archive` シートに記録されるデータは以下のようになり、どのテキストがアーカイブされたのかを特定できませんでした。

| string_id | string_type | text_body | ... | archive_date |
| :--- | :--- | :--- | :--- | :--- |
| | | 要確認 | ... | 2025-07-09 21:16:44 |

## 原因

`pandas`でデータ差分を比較する際、`string_id`と`string_type`をDataFrameのインデックスとして利用していました。
アーカイブ対象の行データを `.loc` で取得する際に、インデックスの列はデータに含まれないため、キー情報が欠落していました。

## 修正内容

アーカイブ用のデータリストを作成する際に、インデックスとして保持しているキー情報 (`string_id`, `string_type`) を明示的に行データに含めるように処理を修正しました。

```python
# 修正前
row_data = old_translate_sheet_df_keyed.loc[key].tolist()

# 修正後
row_values = old_translate_sheet_df_keyed.loc[key].tolist()
row_data = list(key) + row_values
